### PR TITLE
Bugfix: Y is a vowel if preceded by a consonant

### DIFF
--- a/src/main/scala/com/github/aztek/porterstemmer/PorterStemmer.scala
+++ b/src/main/scala/com/github/aztek/porterstemmer/PorterStemmer.scala
@@ -168,7 +168,7 @@ object PorterStemmer {
     def hasConsonantAt(position: Int): Boolean =
       (word.indices contains position) && (word(position) match {
         case 'a' | 'e' | 'i' | 'o' | 'u' ⇒ false
-        case 'y' if hasConsonantAt(position + 1) ⇒ false
+        case 'y' if hasConsonantAt(position - 1) ⇒ false
         case _ ⇒ true
       })
 


### PR DESCRIPTION
Y should be a vowel if preceded by a consonant, not succeeded by a consonant.