### PR TITLE
Update dependencies from scala 2.9 to 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,10 @@
     <artifactId>porterstemmer</artifactId>
     <packaging>jar</packaging>
     <version>0.0.1</version>
+    <properties>
+	    <scala.binary.version>2.11</scala.binary.version>
+	    <scala.version>2.11.7</scala.version>
+    </properties>
 
     <repositories>
         <repository>
@@ -24,46 +28,43 @@
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.9.1</artifactId>
-            <version>1.6.1</version>
+            <artifactId>scalatest_${scala.binary.version}</artifactId>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+    
     </dependencies>
 
     <build>
+        <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
+        <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
-                        <phase>compile</phase>
                         <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.scala-tools</groupId>
-                <artifactId>maven-scala-plugin</artifactId>
-                <version>2.15.2</version>
-                <executions>
-                    <execution>
-                        <id>scala-compile-first</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>add-source</goal>
                             <goal>compile</goal>
                             <goal>testCompile</goal>
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/scala/com/github/aztek/porterstemmer/PorterStemmerTest.scala
+++ b/src/test/scala/com/github/aztek/porterstemmer/PorterStemmerTest.scala
@@ -1,9 +1,8 @@
 package com.github.aztek.porterstemmer
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.junit.JUnitRunner
 
 /**
  * ScalaTest specification for PorterStemmer.

--- a/src/test/scala/com/github/aztek/porterstemmer/PorterStemmerTest.scala
+++ b/src/test/scala/com/github/aztek/porterstemmer/PorterStemmerTest.scala
@@ -3,7 +3,7 @@ package com.github.aztek.porterstemmer
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.Matchers._
 
 /**
  * ScalaTest specification for PorterStemmer.
@@ -11,7 +11,7 @@ import org.scalatest.matchers.ShouldMatchers
  * @author Evgeny Kotelnikov <evgeny.kotelnikov@gmail.com>
  */
 @RunWith(classOf[JUnitRunner])
-class PorterStemmerTest extends FlatSpec with ShouldMatchers {
+class PorterStemmerTest extends FlatSpec {
   behavior of "Porter's stemmer"
 
   it should "stem plurals" in {
@@ -24,7 +24,7 @@ class PorterStemmerTest extends FlatSpec with ShouldMatchers {
     )
 
     for ((word, stem) <- plurals)
-      expect(stem)(PorterStemmer.stem(word))
+      assertResult(stem)(PorterStemmer.stem(word))
   }
 
   it should "stem past participles" in {
@@ -52,7 +52,7 @@ class PorterStemmerTest extends FlatSpec with ShouldMatchers {
     )
 
     for ((word, stem) <- participles)
-      expect(stem)(PorterStemmer.stem(word))
+      assertResult(stem)(PorterStemmer.stem(word))
   }
 
   it should "change suffixes" in {
@@ -115,6 +115,6 @@ class PorterStemmerTest extends FlatSpec with ShouldMatchers {
     )
 
     for ((word, stem) <- changes)
-      expect(stem)(PorterStemmer.stem(word))
+      assertResult(stem)(PorterStemmer.stem(word))
   }
 }


### PR DESCRIPTION
Including: scala version, scalatest, pom.xml updates including maven-scala-plugin -> scala-maven-plugin  and update to a TestCase for changes to ShouldMatcher